### PR TITLE
chore(ci): make the renovate workflow concurrent/atomic

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,6 +15,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
 jobs:
   renovate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Only one workflow will execute at a time, and the pending queue will be conflated.